### PR TITLE
[WIP] moving SwiftmailerBundle docs to bundle repo

### DIFF
--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -7,38 +7,39 @@ Step 1: Download the Bundle
 Open a command console, enter your project directory and execute the
 following command to download the latest stable version of this bundle:
 
-```bash
-$ composer require symfony/swiftmailer-bundle "~2.3"
-```
+.. code-block:: bash
+
+    $ composer require symfony/swiftmailer-bundle "~2.3"
 
 This command requires you to have Composer installed globally, as explained
-in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
-of the Composer documentation.
+in the `installation chapter`_ of the Composer documentation.
 
 Step 2: Enable the Bundle
 -------------------------
 
-Then, enable the bundle by adding the following line in the `app/AppKernel.php`
+Then, enable the bundle by adding the following line in the ``app/AppKernel.php``
 file of your project:
 
-```php
-<?php
-// app/AppKernel.php
+.. code-block:: php
 
-// ...
-class AppKernel extends Kernel
-{
-    public function registerBundles()
+    <?php
+    // app/AppKernel.php
+
+    // ...
+    class AppKernel extends Kernel
     {
-        $bundles = array(
-            // ...
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
 
-            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
-        );
+                new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+            );
+
+            // ...
+        }
 
         // ...
     }
 
-    // ...
-}
-```
+.. _`installation chapter`: https://getcomposer.org/doc/00-intro.md

--- a/Resources/doc/index.rst
+++ b/Resources/doc/index.rst
@@ -1,0 +1,44 @@
+Installation
+============
+
+Step 1: Download the Bundle
+---------------------------
+
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
+
+```bash
+$ composer require symfony/swiftmailer-bundle "~2.3"
+```
+
+This command requires you to have Composer installed globally, as explained
+in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
+of the Composer documentation.
+
+Step 2: Enable the Bundle
+-------------------------
+
+Then, enable the bundle by adding the following line in the `app/AppKernel.php`
+file of your project:
+
+```php
+<?php
+// app/AppKernel.php
+
+// ...
+class AppKernel extends Kernel
+{
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+
+            new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+        );
+
+        // ...
+    }
+
+    // ...
+}
+```


### PR DESCRIPTION
Added installation chapter.

Easy picks on bundle side from https://github.com/symfony/symfony-docs/issues/4983